### PR TITLE
feat(server): adds named "Version" property to GetPluginInfo RPC method

### DIFF
--- a/server.js
+++ b/server.js
@@ -135,6 +135,7 @@ class Server {
 
     return {
       Name: name,
+      Version: plugin.getVersion(),
       Phases: plugin.getPhases(),
       Priority: plugin.getPriority(),
       Schema: {


### PR DESCRIPTION
It looks as though the version prop is inspected by the Data Planes when the plugin is pushed via the clustering connection, and because it isn't populated this results in a nil exception.

I was looking to bump some of the npm deps as part of this PR too but it looks like we're running with different lockfile versions so I didn't want to complicate things!