### PR TITLE
feat(server): Adds Version as named property in GetPluginInfo function

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@types/node": "^14.14.32",
-    "babel-preset-env": "^1.7.0",
     "commander": "^7.1.0",
     "msgpack": "^1.0.3",
     "node-color-log": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@types/node": "^14.14.32",
+    "babel-preset-env": "^1.7.0",
     "commander": "^7.1.0",
     "msgpack": "^1.0.3",
     "node-color-log": "^5.2.0",

--- a/server.js
+++ b/server.js
@@ -135,6 +135,7 @@ class Server {
 
     return {
       Name: name,
+      Version: plugin.getVersion(),
       Phases: plugin.getPhases(),
       Priority: plugin.getPriority(),
       Schema: {


### PR DESCRIPTION
This PR adds a missing property to the plugin information which is retrieved when plugin configurations are pushed to Data Planes. This was originally resulting in a nil exception because this prop didn't exist. Also adds babel-preset-env as a dependency to the package.json