### PR TITLE
fix: reference module process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,16 +2,7 @@
 node_modules/
 /dist/
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-{{#unit}}
-/test/unit/coverage/
-{{/unit}}
-{{#e2e}}
-/test/e2e/reports/
-selenium-debug.log
-{{/e2e}}
-
+coverage/
 # Editor directories and files
 .idea
 .vscode
@@ -19,6 +10,8 @@ selenium-debug.log
 *.ntvs*
 *.njsproj
 *.sln
+*.vim
+*.swp
 
 examples/package-lock.json
 examples/node_modules

--- a/bin/kong-js-pluginserver
+++ b/bin/kong-js-pluginserver
@@ -7,15 +7,15 @@ let path = require('path')
 const msgpack = require("@msgpack/msgpack")
 const logger = require('node-color-log')
 
-let cli = require('kong-pdk/cli')
-let Server = require('kong-pdk/server')
-let Listener = require('kong-pdk/listener')
+let cli = require('../cli')
+let Server = require('../server')
+let Listener = require('../listener')
 
-let opts = cli.parse()
+const opts = cli.parse()
 
 logger.setLevel(opts.logLevel)
 
-let ps = new Server(opts.pluginsDirectory, logger)
+const ps = new Server(opts.pluginsDirectory, logger)
 
 if (opts.DumpPluginInfo) {
   ps.GetPluginInfo(opts.DumpPluginInfo)

--- a/examples/js-hello.js
+++ b/examples/js-hello.js
@@ -1,7 +1,5 @@
 'use strict';
 
-let proc = require("process")
-
 // This is an example plugin that add a header to the response
 
 class KongPlugin {
@@ -20,7 +18,7 @@ class KongPlugin {
     // the following can be "parallel"ed
     await Promise.all([
       kong.response.setHeader("x-hello-from-javascript", "Javascript says " + message + " to " + host),
-      kong.response.setHeader("x-javascript-pid", proc.pid),
+      kong.response.setHeader("x-javascript-pid", process.pid),
     ])
   }
 }

--- a/examples/js-transform.js
+++ b/examples/js-transform.js
@@ -1,7 +1,5 @@
 'use strict';
 
-let proc = require("process")
-
 // This is an example plugin that appends a string in response body
 
 class KongPlugin {

--- a/examples/ts-hello.ts
+++ b/examples/ts-hello.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-let proc = require("process")
 import kong from "kong-pdk/kong"
 
 // This is an example plugin that add a header to the response
@@ -23,7 +22,7 @@ class KongPlugin {
     // the following can be "parallel"ed
     await Promise.all([
       kong.response.setHeader("x-hello-from-javascript", "Javascript says " + message + " to " + host),
-      kong.response.setHeader("x-javascript-pid", proc.pid),
+      kong.response.setHeader("x-javascript-pid", process.pid),
     ])
   }
 }


### PR DESCRIPTION
Process is a module level global created by the node.js runtime.
Requiring the the process module is considered and anti-pattern