### PR TITLE
fix(pdk): remove unnecessary promise wrappers

### DIFF
--- a/examples/js-hello.test.js
+++ b/examples/js-hello.test.js
@@ -3,7 +3,7 @@ const plugin = require('./js-hello');
 const {
 	PluginTest,
 	Request
-} = require("kong-pdk/plugin_test")
+} = require("../plugin_test")
 
 
 test('Set headers in response', async () => {

--- a/examples/js-transform.test.js
+++ b/examples/js-transform.test.js
@@ -3,7 +3,7 @@ const plugin = require('./js-transform');
 const {
   PluginTest,
   Request
-} = require("kong-pdk/plugin_test")
+} = require("../plugin_test")
 
 
 test('Set headers in response', async () => {

--- a/examples/pdk.test.js
+++ b/examples/pdk.test.js
@@ -1,0 +1,19 @@
+const PDK = require('../pdk')
+const PipePair = require('../lib/pipe')
+
+test('kong js pdk', async () => {
+  let [_, child] = new PipePair().getPair()
+  const pdk = new PDK(child)
+  expect('' + pdk).toBe('[object KongPDK]')
+  expect(new pdk.Error).toBeInstanceOf(Error)
+
+  {
+    const error = new pdk.Error('this is an error')
+    expect('' + error).toBe('PDKError: this is an error')
+  }
+
+  {
+    const error = new PDK.Error('this is an error')
+    expect('' + error).toBe('PDKError: this is an error')
+  }
+})

--- a/examples/ts-hello.ts
+++ b/examples/ts-hello.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import kong from "kong-pdk/kong"
+import kong from "../kong"
 
 // This is an example plugin that add a header to the response
 


### PR DESCRIPTION
Removes places where promises wrappers were used to return errors inside
of `async` functions. This inherently happens when throwing an error
from an async function and only results in the overhead of an additional
promise.