### PR TITLE
fix(server): correct error constructor arguments

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ class PluginServerError extends Error {
     return ERROR_NAME
   }
 
-  constructor(args) {
+  constructor(...args) {
     super(...args)
     Error.captureStackTrace(this, this.constructor)
   }


### PR DESCRIPTION
The error sub class was improperly attempting to spread function
arguments that were being passed as a string which resulted in the error
message containing only the first letter