### PR TITLE
Plugin test response status

### DIFF
--- a/__tests__/js-status.test.js
+++ b/__tests__/js-status.test.js
@@ -1,0 +1,44 @@
+const plugin = require('../examples/js-status');
+
+const {
+  PluginTest,
+  Request
+} = require("../plugin_test")
+
+
+test('Should succeed with status 200 when header is present', async () => {
+  let r = new Request()
+
+  r
+    .useURL("http://example.com")
+    .useMethod("GET")
+    .useHeaders({
+      "userId": "test-id",
+    })
+
+  let t = new PluginTest(r)
+
+  await t.Run(plugin, {
+    "message": "test",
+  })
+
+  expect(t.response.status).toBe(200)
+  expect(t.response.headers.get('x-welcome'))
+    .toBe('Javascript says test to test-id')
+});
+
+test('Should exit with status 403 when header is missing', async () => {
+  let r = new Request()
+
+  r
+    .useURL("http://example.com")
+    .useMethod("GET")
+
+  let t = new PluginTest(r)
+
+  await t.Run(plugin, {
+    "message": "test",
+  })
+
+  expect(t.response.status).toBe(403)
+});

--- a/examples/js-status.js
+++ b/examples/js-status.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// This is an example plugin that sets the response status based on the existence of a header
+
+class KongPlugin {
+  constructor(config) {
+    this.config = config
+  }
+
+  async access(kong) {
+    let userId = await kong.request.getHeader("userId")
+    if (!userId) {
+      return kong.response.exit(403);
+    }
+
+    let message = this.config.message || "hello"
+
+    await Promise.all([
+      kong.response.setHeader("x-welcome", "Javascript says " + message + " to " + userId),
+    ])
+  }
+}
+
+module.exports = {
+  Plugin: KongPlugin,
+  Schema: [
+    { message: { type: "string" } },
+  ],
+  Version: '0.1.0',
+  Priority: 0,
+}

--- a/plugin_test.js
+++ b/plugin_test.js
@@ -174,7 +174,7 @@ class PluginTest {
     } else{
       await this.executePhase(pluginInstance, "access")
       await this.executePhase(pluginInstance, "rewrite")
-      if (this.response.status === undefined) {
+      if (!this.exiting) {
         this.serviceResponse = this.serviceRequest.toResponse()
         this.response.merge(this.serviceResponse)
       }

--- a/plugin_test.js
+++ b/plugin_test.js
@@ -174,8 +174,10 @@ class PluginTest {
     } else{
       await this.executePhase(pluginInstance, "access")
       await this.executePhase(pluginInstance, "rewrite")
-      this.serviceResponse = this.serviceRequest.toResponse()
-      this.response.merge(this.serviceResponse)
+      if (this.response.status === undefined) {
+        this.serviceResponse = this.serviceRequest.toResponse()
+        this.response.merge(this.serviceResponse)
+      }
       await this.executePhase(pluginInstance, "response")
     }
 


### PR DESCRIPTION
It was noticed that in a plugin particularly in the access lifecycle method when you exit the response with a status code you cannot unit test it as the response status is always overiden by the hardcoded serviceResponse. 

The examples commit shows this error in a simple example plugin and corresponding unit tests. 

We have implemented a fix by conditionally merging the serviceResponse into the instance response only if the instance response.status is undefined. This works however i am not to sure why the instance response.status is undefined in the first place.