### PR TITLE
fixed the assignment of mocked log functions in plugin_test.js

### DIFF
--- a/__tests__/pluing.test.js
+++ b/__tests__/pluing.test.js
@@ -10,6 +10,7 @@ const {
 test('plugin interface', async () => {
   let r = new Request()
   const start = Date.now() / 1000
+  await sleep(1000)
 
   r
     .useURL("http://example.com")
@@ -23,8 +24,6 @@ test('plugin interface', async () => {
     "message": "test",
   })
 
-
-  await sleep(1000)
   expect(mod.getLastStartInstanceTime()).toBeGreaterThan(start)
   expect(mod.getName()).toBe('goodbye')
   expect(mod.getPhases()).toEqual(expect.arrayContaining(['access']))

--- a/plugin_test.js
+++ b/plugin_test.js
@@ -144,9 +144,10 @@ let logFunctions = [
   "kong.log.notice", "kong.log.info", "kong.log.debug"
 ]
 
-for (let f in logFunctions) {
-  mockFunctions[f] = function(...args) {
-    console.log("Log " + f, ...args)
+for (let i = 0; i < logFunctions.length; i++) {
+  const logFunction = logFunctions[i];
+  mockFunctions[logFunction] = function(...args) {
+    console.log("Log " + logFunction, ...args)
   }
 }
 

--- a/plugin_test.js
+++ b/plugin_test.js
@@ -145,7 +145,7 @@ let logFunctions = [
 ]
 
 for (let i = 0; i < logFunctions.length; i++) {
-  const logFunction = logFunctions[i];
+  const logFunction = logFunctions[i]
   mockFunctions[logFunction] = function(...args) {
     console.log("Log " + logFunction, ...args)
   }


### PR DESCRIPTION
I was writing tests for a Kong JS Plugin, and encountered `Error: function kong.log.err is not a valid PDK function` whenever the plugin tried to interact with `await kong.log.err("insert-error-here");`.

After looking into the code, I found the `mockFunctions` in `plugin_test.js` where assigned under the index not the value of the elements in `logFunctions`.

I traced the issue to the for-in loop the returning the index not the value of the elements of `logFunctions`.

In this PR the assignment has been changed to use the name and not the index by using a basic for loop.

I hope these changes are good enough to be merged into the mainline.
If not the feedback would be appreciated.