### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,7 +60,8 @@ class Server {
 
     const files = fs.readdirSync(this.pluginDir)
     for (const file of files) {
-
+      
+      if (files[file].startsWith('.')) continue
       if (/node_modules/.test(file)) continue
       const file_path = require.resolve(path.join(this.pluginDir, file))
       const {name, ext} = path.parse(file_path)


### PR DESCRIPTION
It looks like with git people can use the marker file .gitkeep to ensure that git will save an empty directory, as can be seen from the jdk example we provide.  We should ignore files/directories that start with the character '.' when processing files in the plugins directory as they are meant to be hidden.  Or at the very least this specific file `.gitkeep`.  I think all files/directories that start with '.' should be ignored during the loading process.