### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,6 +61,7 @@ class Server {
     const files = fs.readdirSync(this.pluginDir)
     for (const file of files) {
 
+      if (file.startsWith('.')) continue
       if (/node_modules/.test(file)) continue
       const file_path = require.resolve(path.join(this.pluginDir, file))
       const {name, ext} = path.parse(file_path)


### PR DESCRIPTION
Sometimes people use `.gitkeep` to force git to save an empty directory, this has the side effect that it becomes a file in that directory, plugins in our case.  When loading plugins the server tries all entries including this file as a plugin.  This causes an error.

We should ignore files that start with a '.' in the plugins directory.