### PR TITLE
doc(readme) update Kong Docs links to appropriate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires Kong >= 2.3.0.
 
 ## Documentation
 
-See in [Kong Docs](https://docs.konghq.com/gateway-oss/latest/external-plugins/#developing-javascript-plugins).
+See in [Kong Docs](https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/javascript/).
 
 ## TODO
 


### PR DESCRIPTION
Hello Kong team, 👋

Minor change for this Pull request.

In the `README.md` file, replace the Kong Docs URL: 
* Old: https://docs.konghq.com/gateway-oss/latest/external-plugins/#developing-javascript-plugins
* New: https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/javascript/

Hope this helps! ✌